### PR TITLE
animation controllerのインスタンスかを修正

### DIFF
--- a/lib/src/inner_infinite_scroll_tab_view.dart
+++ b/lib/src/inner_infinite_scroll_tab_view.dart
@@ -94,12 +94,7 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
   double get indicatorHeight =>
       widget.indicatorHeight ?? widget.separator?.width ?? 2.0;
 
-  late final _indicatorAnimationController =
-      AnimationController(vsync: this, duration: _tabAnimationDuration)
-        ..addListener(() {
-          if (_indicatorAnimation == null) return;
-          _indicatorSize.value = _indicatorAnimation!.value;
-        });
+  late final _indicatorAnimationController;
   Animation<double>? _indicatorAnimation;
 
   double _totalTabSizeCache = 0.0;
@@ -192,6 +187,13 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
   @override
   void initState() {
     super.initState();
+
+    _indicatorAnimationController =
+      AnimationController(vsync: this, duration: _tabAnimationDuration)
+        ..addListener(() {
+          if (_indicatorAnimation == null) return;
+          _indicatorSize.value = _indicatorAnimation!.value;
+        });
 
     calculateTabBehaviorElements(widget.textScaleFactor);
 


### PR DESCRIPTION
以下のエラーが出てました。
原因としてはAnimationControllerをinitStateでインスタンス化してないからでした。
[大元のリポジトリ](https://github.com/cb-cloud/flutter_infinite_scroll_tab_view)は2年前が最後のコミットなのでforkして使うようにしました。

スニダンリポジトリのpubspec.ymlの修正はこちら https://github.com/snkrdunk/snkrdunk_flutter/pull/4420

```
The following assertion was thrown while finalizing the widget tree:
Looking up a deactivated widget's ancestor is unsafe.

At this point the state of the widget's element tree is no longer stable.

To safely refer to a widget's ancestor in its dispose() method, save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() in the widget's didChangeDependencies() method.

When the exception was thrown, this was the stack
```