### PR TITLE
forwardメソッドを呼ぶ際にdoubleを渡す

### DIFF
--- a/lib/src/inner_infinite_scroll_tab_view.dart
+++ b/lib/src/inner_infinite_scroll_tab_view.dart
@@ -96,7 +96,7 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
   double get indicatorHeight =>
       widget.indicatorHeight ?? widget.separator?.width ?? 2.0;
 
-  late final _indicatorAnimationController;
+  late final AnimationController _indicatorAnimationController;
   Animation<double>? _indicatorAnimation;
 
   double _totalTabSizeCache = 0.0;
@@ -265,7 +265,7 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
     _indicatorAnimation =
         Tween(begin: _indicatorSize.value, end: _tabTextSizes[modIndex])
             .animate(_indicatorAnimationController);
-    _indicatorAnimationController.forward(from: 0);
+    _indicatorAnimationController.forward(from: 0.0);
 
     // 現在のスクロール位置とページインデックスを取得
     final currentOffset = _pageController.offset;


### PR DESCRIPTION
タブバーをタップした際にエラーが起きていました。
animation controllerのforwardに渡す値がdoubleではなくintで怒られていました。
0ではなく、0.0にしました