### PR TITLE
コンテンツ数が変わった時に再計算する

### DIFF
--- a/lib/src/inner_infinite_scroll_tab_view.dart
+++ b/lib/src/inner_infinite_scroll_tab_view.dart
@@ -187,6 +187,17 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
   }
 
   @override
+  void didUpdateWidget(InnerInfiniteScrollTabView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.contentLength != widget.contentLength) {
+      final textScaleFactor = MediaQuery.textScaleFactorOf(context);
+      setState(() {
+        calculateTabBehaviorElements(textScaleFactor);
+      });
+    }
+  }
+
+  @override
   void initState() {
     super.initState();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: infinite_scroll_tab_view
 description: A Flutter package for tab view component that can scroll infinitely.
-version: 1.0.5
+version: 1.0.6
 repository: https://github.com/cb-cloud/flutter_infinite_scroll_tab_view
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: infinite_scroll_tab_view
 description: A Flutter package for tab view component that can scroll infinitely.
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/cb-cloud/flutter_infinite_scroll_tab_view
 
 environment:


### PR DESCRIPTION
contentLengthが変わった時にcalculateTabBehaviorElementsをしないとタブが以下のようにバグっていたので修正しました。
(内部的にタブ数が再設定されてなかったのでへんな挙動になっていました)

- 最後のタブと最初のタブの移動時にインジケーターがかくつく
- 2つ隣のタブをタップしたら、選択インジケータがおかしくなる

