### PR TITLE
各タブのタブラベル部分に任意の UI を重ねられるようにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.7
 
-- `InnerInfiniteScrollTabView` に任意の `Widget? stackedContent` を指定してタブラベルに重ねて任意の UI を表示できるようにしました。
+- `InnerInfiniteScrollTabView` に `Widget? stackedContentOnTabBuilder` を指定してタブラベルに重ねて任意の UI を表示できるようにしました。
 - `.gitignore` に `pubspec.lock` を追加しました。
 
 ## 1.0.3

--- a/lib/src/infinite_scroll_tab_view.dart
+++ b/lib/src/infinite_scroll_tab_view.dart
@@ -23,6 +23,7 @@ class InfiniteScrollTabView extends StatelessWidget {
     Key? key,
     required this.contentLength,
     required this.tabBuilder,
+    this.stackedContentOnTabBuilder,
     required this.pageBuilder,
     this.onTabTap,
     this.separator,
@@ -36,7 +37,6 @@ class InfiniteScrollTabView extends StatelessWidget {
     this.forceFixedTabWidth = false,
     this.fixedTabWidthFraction = 0.5,
     this.physics = const PageScrollPhysics(),
-    this.stackedContent,
   }) : super(key: key);
 
   /// A length of tabs and pages.
@@ -56,6 +56,11 @@ class InfiniteScrollTabView extends StatelessWidget {
   /// `index` is modulo number of real index by [contentLength].
   /// `isSelected` is the state that indicates whether the tab is selected or not.
   final SelectIndexedTextBuilder tabBuilder;
+
+  /// [tabBuilder] で表示されるタブラベルに [Stack] で重ねて表示するウィジェット。
+  ///
+  /// 典型的には [Positioned] を使って、タブの上にバッジを表示するなどの目的で使用する。
+  final SelectIndexedWidgetBuilder? stackedContentOnTabBuilder;
 
   /// A callback for build page contents that can scroll infinitely.
   ///
@@ -135,11 +140,6 @@ class InfiniteScrollTabView extends StatelessWidget {
 
   final ScrollPhysics physics;
 
-  /// タブラベルに [Stack] で重ねて表示するウィジェット。
-  ///
-  /// 典型的には [Positioned] を使って、タブの上にバッジを表示するなどの目的で使用する。
-  final Widget? stackedContent;
-
   @override
   Widget build(BuildContext context) {
     if (indicatorHeight != null) {
@@ -150,6 +150,7 @@ class InfiniteScrollTabView extends StatelessWidget {
       size: MediaQuery.of(context).size,
       contentLength: contentLength,
       tabBuilder: tabBuilder,
+      stackedContentOnTabBuilder: stackedContentOnTabBuilder,
       pageBuilder: pageBuilder,
       onTabTap: onTabTap,
       separator: separator,
@@ -166,7 +167,6 @@ class InfiniteScrollTabView extends StatelessWidget {
       forceFixedTabWidth: forceFixedTabWidth,
       fixedTabWidthFraction: fixedTabWidthFraction,
       physics: physics,
-      stackedContent: stackedContent,
     );
   }
 }

--- a/lib/src/inner_infinite_scroll_tab_view.dart
+++ b/lib/src/inner_infinite_scroll_tab_view.dart
@@ -15,6 +15,7 @@ class InnerInfiniteScrollTabView extends StatefulWidget {
     required this.size,
     required this.contentLength,
     required this.tabBuilder,
+    required this.stackedContentOnTabBuilder,
     required this.pageBuilder,
     this.onTabTap,
     this.separator,
@@ -30,13 +31,18 @@ class InnerInfiniteScrollTabView extends StatefulWidget {
     required this.tabPadding,
     required this.forceFixedTabWidth,
     required this.fixedTabWidthFraction,
-    this.stackedContent,
     this.physics = const PageScrollPhysics(),
   }) : super(key: key);
 
   final Size size;
   final int contentLength;
   final SelectIndexedTextBuilder tabBuilder;
+
+  /// [_TabContent] のタブラベル部分に [Stack] で重ねて表示するウィジェット。
+  ///
+  /// 典型的には [Positioned] を使って、タブの上にバッジを表示するなどの目的で使用する。
+  final SelectIndexedWidgetBuilder? stackedContentOnTabBuilder;
+
   final SelectIndexedWidgetBuilder pageBuilder;
   final IndexedTapCallback? onTabTap;
   final BorderSide? separator;
@@ -53,11 +59,6 @@ class InnerInfiniteScrollTabView extends StatefulWidget {
   final bool forceFixedTabWidth;
   final double fixedTabWidthFraction;
   final ScrollPhysics physics;
-
-  /// [_TabContent] に [Stack] で重ねて表示するウィジェット。
-  ///
-  /// 典型的には [Positioned] を使って、タブの上にバッジを表示するなどの目的で使用する。
-  final Widget? stackedContent;
 
   @override
   InnerInfiniteScrollTabViewState createState() =>
@@ -372,24 +373,20 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
               valueListenable: _selectedIndex,
               builder: (context, index, _) => ValueListenableBuilder<bool>(
                 valueListenable: _isTabPositionAligned,
-                builder: (context, tab, _) => Stack(
-                  children: [
-                    _TabContent(
-                      isTabPositionAligned: tab,
-                      selectedIndex: index,
-                      indicatorColor: widget.indicatorColor,
-                      tabPadding: widget.tabPadding,
-                      modIndex: modIndex,
-                      tabBuilder: widget.tabBuilder,
-                      separator: widget.separator,
-                      tabWidth: widget.forceFixedTabWidth
-                          ? _fixedTabWidth
-                          : _tabTextSizes[modIndex],
-                      indicatorHeight: indicatorHeight,
-                      indicatorWidth: _tabTextSizes[modIndex],
-                    ),
-                    if (widget.stackedContent != null) widget.stackedContent!,
-                  ],
+                builder: (context, tab, _) => _TabContent(
+                  isTabPositionAligned: tab,
+                  selectedIndex: index,
+                  indicatorColor: widget.indicatorColor,
+                  tabPadding: widget.tabPadding,
+                  modIndex: modIndex,
+                  tabBuilder: widget.tabBuilder,
+                  stackedContentOnTabBuilder: widget.stackedContentOnTabBuilder,
+                  separator: widget.separator,
+                  tabWidth: widget.forceFixedTabWidth
+                      ? _fixedTabWidth
+                      : _tabTextSizes[modIndex],
+                  indicatorHeight: indicatorHeight,
+                  indicatorWidth: _tabTextSizes[modIndex],
                 ),
               ),
             ),
@@ -435,6 +432,7 @@ class _TabContent extends StatelessWidget {
     required this.tabPadding,
     required this.indicatorColor,
     required this.tabBuilder,
+    required this.stackedContentOnTabBuilder,
     this.separator,
     required this.indicatorHeight,
     required this.indicatorWidth,
@@ -447,6 +445,7 @@ class _TabContent extends StatelessWidget {
   final double tabPadding;
   final Color indicatorColor;
   final SelectIndexedTextBuilder tabBuilder;
+  final SelectIndexedWidgetBuilder? stackedContentOnTabBuilder;
   final BorderSide? separator;
   final double indicatorHeight;
   final double indicatorWidth;
@@ -485,7 +484,10 @@ class _TabContent extends StatelessWidget {
                 ),
               ),
             ),
-          )
+          ),
+        if (stackedContentOnTabBuilder != null)
+          stackedContentOnTabBuilder!(
+              context, modIndex, selectedIndex == modIndex),
       ],
     );
   }


### PR DESCRIPTION
各タブのタブラベル部分に任意の UI を重ねられるようにしました。

前回の PR:

https://github.com/snkrdunk/flutter_infinite_scroll_tab_view/pull/6

では `stackedContent` のインターフェースを追加していましたがやりたいことに合わないことに気づき、それは削除して今回のようにしました。

今回の変更で各タブを index で区別しながら任意のタブのラベル部分に Stack で任意の UI を重ねられるようにしました。

今回の変更まで含めて v1.0.7 でタグを切るようにするつもりです。

手元で snkrdunk に適用した例：

![image](https://github.com/cb-cloud/flutter_infinite_scroll_tab_view/assets/13669049/fa1899e6-5429-4235-9845-2d3b632e8d56)