### PR TITLE
タブラベルに上下方向の余白を付けられるようにする

### DIFF
--- a/lib/src/infinite_scroll_tab_view.dart
+++ b/lib/src/infinite_scroll_tab_view.dart
@@ -32,7 +32,7 @@ class InfiniteScrollTabView extends StatelessWidget {
     this.indicatorColor = Colors.pinkAccent,
     this.indicatorHeight,
     this.tabHeight = 44.0,
-    this.tabPadding = 12.0,
+    this.tabHorizontalPadding = 12.0,
     this.size,
     this.forceFixedTabWidth = false,
     this.fixedTabWidthFraction = 0.5,
@@ -107,12 +107,14 @@ class InfiniteScrollTabView extends StatelessWidget {
   /// Defaults to 44.0.
   final double tabHeight;
 
-  /// The padding value of each tab contents.
+  /// タブラベルの左右方向の余白。
   ///
-  /// Defaults to 12.0.
-  /// This value sets as horizontal padding. For example, specify 12.0 then
-  /// the tabs will have padding as `EdgeInsets.symmetric(horizontal: 12.0)`.
-  final double tabPadding;
+  /// デフォルトでは `12.0` が設定されている。
+  ///
+  /// [tabBuilder] で与えた [Text] ウィジェットの左右側に設定され、
+  /// [InnerInfiniteScrollTabView] の中では水平方向のタブ移動の移動量の計算にも使用されて
+  /// いる。
+  final double tabHorizontalPadding;
 
   /// The size constraint of this widget.
   ///
@@ -163,7 +165,7 @@ class InfiniteScrollTabView extends StatelessWidget {
       indicatorHeight: indicatorHeight,
       defaultLocale: Localizations.localeOf(context),
       tabHeight: tabHeight,
-      tabPadding: tabPadding,
+      tabHorizontalPadding: tabHorizontalPadding,
       forceFixedTabWidth: forceFixedTabWidth,
       fixedTabWidthFraction: fixedTabWidthFraction,
       physics: physics,

--- a/lib/src/infinite_scroll_tab_view.dart
+++ b/lib/src/infinite_scroll_tab_view.dart
@@ -33,6 +33,8 @@ class InfiniteScrollTabView extends StatelessWidget {
     this.indicatorHeight,
     this.tabHeight = 44.0,
     this.tabHorizontalPadding = 12.0,
+    this.tabTopPadding = 0,
+    this.tabBottomPadding = 0,
     this.size,
     this.forceFixedTabWidth = false,
     this.fixedTabWidthFraction = 0.5,
@@ -116,6 +118,22 @@ class InfiniteScrollTabView extends StatelessWidget {
   /// いる。
   final double tabHorizontalPadding;
 
+  /// タブラベルの上方向の余白。
+  ///
+  /// デフォルトでは `0` が設定されている。
+  ///
+  /// [tabHeight] の中で [tabTopPadding] に設定した大きさの余白が、[tabBuilder] で与えた
+  /// [Text] ウィジェットの上側に設定される。
+  final double tabTopPadding;
+
+  /// タブラベルの下方向の余白。
+  ///
+  /// デフォルトでは `0` が設定されている。
+  ///
+  /// [tabHeight] の中で [tabTopPadding] に設定した大きさの余白が、[tabBuilder] で与えた
+  /// [Text] ウィジェットの下側に設定される。
+  final double tabBottomPadding;
+
   /// The size constraint of this widget.
   ///
   /// If this is null, then `MediaQuery.of(context).size` is used as default.
@@ -166,6 +184,8 @@ class InfiniteScrollTabView extends StatelessWidget {
       defaultLocale: Localizations.localeOf(context),
       tabHeight: tabHeight,
       tabHorizontalPadding: tabHorizontalPadding,
+      tabTopPadding: tabTopPadding,
+      tabBottomPadding: tabBottomPadding,
       forceFixedTabWidth: forceFixedTabWidth,
       fixedTabWidthFraction: fixedTabWidthFraction,
       physics: physics,

--- a/lib/src/inner_infinite_scroll_tab_view.dart
+++ b/lib/src/inner_infinite_scroll_tab_view.dart
@@ -29,6 +29,8 @@ class InnerInfiniteScrollTabView extends StatefulWidget {
     required this.defaultLocale,
     required this.tabHeight,
     required this.tabHorizontalPadding,
+    required this.tabTopPadding,
+    required this.tabBottomPadding,
     required this.forceFixedTabWidth,
     required this.fixedTabWidthFraction,
     this.physics = const PageScrollPhysics(),
@@ -56,6 +58,8 @@ class InnerInfiniteScrollTabView extends StatefulWidget {
   final Locale defaultLocale;
   final double tabHeight;
   final double tabHorizontalPadding;
+  final double tabTopPadding;
+  final double tabBottomPadding;
   final bool forceFixedTabWidth;
   final double fixedTabWidthFraction;
   final ScrollPhysics physics;
@@ -379,6 +383,8 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
                   selectedIndex: index,
                   indicatorColor: widget.indicatorColor,
                   tabHorizontalPadding: widget.tabHorizontalPadding,
+                  tabTopPadding: widget.tabTopPadding,
+                  tabBottomPadding: widget.tabBottomPadding,
                   modIndex: modIndex,
                   tabBuilder: widget.tabBuilder,
                   stackedContentOnTabBuilder: widget.stackedContentOnTabBuilder,
@@ -431,6 +437,8 @@ class _TabContent extends StatelessWidget {
     required this.selectedIndex,
     required this.modIndex,
     required this.tabHorizontalPadding,
+    required this.tabTopPadding,
+    required this.tabBottomPadding,
     required this.indicatorColor,
     required this.tabBuilder,
     required this.stackedContentOnTabBuilder,
@@ -444,6 +452,8 @@ class _TabContent extends StatelessWidget {
   final int selectedIndex;
   final bool isTabPositionAligned;
   final double tabHorizontalPadding;
+  final double tabTopPadding;
+  final double tabBottomPadding;
   final Color indicatorColor;
   final SelectIndexedTextBuilder tabBuilder;
   final SelectIndexedWidgetBuilder? stackedContentOnTabBuilder;
@@ -459,7 +469,12 @@ class _TabContent extends StatelessWidget {
       children: [
         Container(
           width: tabWidth,
-          padding: EdgeInsets.symmetric(horizontal: tabHorizontalPadding),
+          padding: EdgeInsets.only(
+            left: tabHorizontalPadding,
+            right: tabHorizontalPadding,
+            top: tabTopPadding,
+            bottom: tabBottomPadding,
+          ),
           decoration: BoxDecoration(
             border: Border(bottom: separator ?? BorderSide.none),
           ),

--- a/lib/src/inner_infinite_scroll_tab_view.dart
+++ b/lib/src/inner_infinite_scroll_tab_view.dart
@@ -28,7 +28,7 @@ class InnerInfiniteScrollTabView extends StatefulWidget {
     this.indicatorHeight,
     required this.defaultLocale,
     required this.tabHeight,
-    required this.tabPadding,
+    required this.tabHorizontalPadding,
     required this.forceFixedTabWidth,
     required this.fixedTabWidthFraction,
     this.physics = const PageScrollPhysics(),
@@ -55,7 +55,7 @@ class InnerInfiniteScrollTabView extends StatefulWidget {
   final double? indicatorHeight;
   final Locale defaultLocale;
   final double tabHeight;
-  final double tabPadding;
+  final double tabHorizontalPadding;
   final bool forceFixedTabWidth;
   final double fixedTabWidthFraction;
   final ScrollPhysics physics;
@@ -152,7 +152,8 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
         textScaleFactor: text.textScaleFactor ?? textScaleFactor,
         textDirection: widget.textDirection,
       )..layout();
-      final calculatedWidth = layoutedText.size.width + widget.tabPadding * 2;
+      final calculatedWidth =
+          layoutedText.size.width + widget.tabHorizontalPadding * 2;
       final sizeConstraint =
           widget.forceFixedTabWidth ? _fixedTabWidth : widget.size.width;
       _tabTextSizes.add(math.min(calculatedWidth, sizeConstraint));
@@ -377,7 +378,7 @@ class InnerInfiniteScrollTabViewState extends State<InnerInfiniteScrollTabView>
                   isTabPositionAligned: tab,
                   selectedIndex: index,
                   indicatorColor: widget.indicatorColor,
-                  tabPadding: widget.tabPadding,
+                  tabHorizontalPadding: widget.tabHorizontalPadding,
                   modIndex: modIndex,
                   tabBuilder: widget.tabBuilder,
                   stackedContentOnTabBuilder: widget.stackedContentOnTabBuilder,
@@ -429,7 +430,7 @@ class _TabContent extends StatelessWidget {
     required this.isTabPositionAligned,
     required this.selectedIndex,
     required this.modIndex,
-    required this.tabPadding,
+    required this.tabHorizontalPadding,
     required this.indicatorColor,
     required this.tabBuilder,
     required this.stackedContentOnTabBuilder,
@@ -442,7 +443,7 @@ class _TabContent extends StatelessWidget {
   final int modIndex;
   final int selectedIndex;
   final bool isTabPositionAligned;
-  final double tabPadding;
+  final double tabHorizontalPadding;
   final Color indicatorColor;
   final SelectIndexedTextBuilder tabBuilder;
   final SelectIndexedWidgetBuilder? stackedContentOnTabBuilder;
@@ -458,7 +459,7 @@ class _TabContent extends StatelessWidget {
       children: [
         Container(
           width: tabWidth,
-          padding: EdgeInsets.symmetric(horizontal: tabPadding),
+          padding: EdgeInsets.symmetric(horizontal: tabHorizontalPadding),
           decoration: BoxDecoration(
             border: Border(bottom: separator ?? BorderSide.none),
           ),

--- a/test/infinite_scroll_tab_view_test.dart
+++ b/test/infinite_scroll_tab_view_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_scroll_tab_view/infinite_scroll_tab_view.dart';
 import 'package:infinite_scroll_tab_view/src/inner_infinite_scroll_tab_view.dart';
@@ -43,7 +42,7 @@ void main() {
           MaterialApp(
             home: InfiniteScrollTabView(
               contentLength: strings.length,
-              tabPadding: 4.0,
+              tabHorizontalPadding: 4.0,
               tabBuilder: (index, _) => Text(
                 strings[index],
                 style: const TextStyle(
@@ -113,7 +112,7 @@ void main() {
           MaterialApp(
             home: InfiniteScrollTabView(
               contentLength: strings.length,
-              tabPadding: 4.0,
+              tabHorizontalPadding: 4.0,
               tabBuilder: (index, _) => Text(
                 strings[index],
                 style: const TextStyle(


### PR DESCRIPTION
タブラベルに上下方向の余白を付けられるようにしました。

- 1fc0db18d4418e920628bfb1ac0f1f5abccd3dd4: 既存の `tabPadding` を `tabHorizontalPadding` に機械的にリネームしました
- 092b9585c7e158058aa0073a9a0183120233a6a6: `tabTopPadding`, `tabBottomPadding` を設定できるようにしました

イメージとしては、下記のような使い方をする予定です。マーケットでも検索でもタブラベルの上部に従来より余白のある見た目になっています。

<img src="https://github.com/snkrdunk/flutter_infinite_scroll_tab_view/assets/13669049/ea672410-c132-4157-9112-5cc1f8b818e8" width="320">